### PR TITLE
Activate SSL when SASL/PLAIN is used

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -99,7 +99,7 @@ export class Client implements Disposable {
             sasl: this.sasl,
             connectTimeout: 3000,
             kafkaHost: this.host,
-
+            sslOptions: this.sasl ? {} : undefined
         });
 
         this.kafkaAdminClient = new kafka.Admin(this.kafkaClient);


### PR DESCRIPTION
Quoting [Kafka documentation](https://docs.confluent.io/current/kafka/authentication_sasl/authentication_sasl_plain.html):
> SASL/PLAIN should only be used with SSL as transport layer to ensure that clear passwords are not transmitted on the wire without encryption.

Right now, the extension does not activate SSL when creating the KafkaClient instance.
Doing so requires passing the `sslOptions` flag to KafkaClient (giving it a value of `{}` is enough).

This MR enables SSL when SASL/PLAIN is used.

I see things this way:
- short term, fix the security gap by forcing SSL when using SASL/PLAIN (this MR does that),
- medium term, add a boolean configuration flag to enable/disable SSL,
- long term, allow passing the various flags supported by TLS sockets.

Thanks a lot of this great extension.