### PR TITLE
Activate SSL in Consumer when SASL is used

### DIFF
--- a/src/client/consumer.ts
+++ b/src/client/consumer.ts
@@ -59,6 +59,7 @@ class Consumer implements vscode.Disposable {
             kafkaHost: this.options.kafkaHost,
             fromOffset: this.options.fromOffset,
             sasl: this.options.sasl,
+            sslOptions: this.options.sasl ? {} : undefined,
             groupId: "vscode-kafka-" + this.options.topic,
         }, [this.options.topic]);
 


### PR DESCRIPTION
Hi. I didn't notice in my previous PR #4 that the connection flags are duplicated in the Consumer code.
The Producer seems to reuse the Admin client but not the Consumer.

This PR applies the same code to enable SSL when SASL is used.

Thanks,
Joan