### PR TITLE
Improved the `New Kafka cluster` wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 All notable changes to Kafka extension will be documented in this file.
+## [0.10.0] - TBD
+### Changed
+- Fixed Kafka cluster wizard, no longer disappears when losing focus
 
 ## [0.9.0] - 2020-05-30
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Kafka extension for Visual Studio Code
 
-![CI](https://img.shields.io/github/workflow/status/jlandersen/vscode-kafka/CI)
+[![CI](https://img.shields.io/github/workflow/status/jlandersen/vscode-kafka/CI/master)](https://github.com/jlandersen/vscode-kafka/actions?query=workflow%3ACI+branch%3Amaster)
+[![Latest version](https://img.shields.io/visual-studio-marketplace/v/jeppeandersen.vscode-kafka?color=brightgreen)](https://marketplace.visualstudio.com/items?itemName=jeppeandersen.vscode-kafka)
+[![Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/jeppeandersen.vscode-kafka?logo=Installs)](https://marketplace.visualstudio.com/items?itemName=jeppeandersen.vscode-kafka)
 
 Work with Kafka directly in Visual Studio Code. Kafka clusters running version 0.11 or higher are supported.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-kafka",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -675,8 +675,7 @@
         "base64-js": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-            "dev": true
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
         },
         "big.js": {
             "version": "5.2.2",
@@ -3129,8 +3128,7 @@
         "ieee754": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-            "dev": true
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
         "iferr": {
             "version": "0.1.5",
@@ -3814,9 +3812,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "mississippi": {
             "version": "3.0.0",
@@ -3858,19 +3856,18 @@
             }
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
             "requires": {
-                "minimist": "0.0.8"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-                }
+                "minimist": "^1.2.5"
             }
+        },
+        "mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+            "optional": true
         },
         "mocha": {
             "version": "6.2.3",
@@ -4816,10 +4813,13 @@
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         },
         "serialize-javascript": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-            "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-            "dev": true
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "^2.1.0"
+            }
         },
         "set-blocking": {
             "version": "2.0.0",
@@ -5325,24 +5325,24 @@
             "dev": true
         },
         "tar-fs": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
-            "integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
             "optional": true,
             "requires": {
                 "chownr": "^1.1.1",
-                "mkdirp": "^0.5.1",
+                "mkdirp-classic": "^0.5.2",
                 "pump": "^3.0.0",
-                "tar-stream": "^2.0.0"
+                "tar-stream": "^2.1.4"
             }
         },
         "tar-stream": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
-            "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+            "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
             "optional": true,
             "requires": {
-                "bl": "^3.0.0",
+                "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
                 "fs-constants": "^1.0.0",
                 "inherits": "^2.0.3",
@@ -5350,18 +5350,30 @@
             },
             "dependencies": {
                 "bl": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.1.tgz",
-                    "integrity": "sha512-jrCW5ZhfQ/Vt07WX1Ngs+yn9BDqPL/gw28S7s9H6QK/gupnizNzJAss5akW20ISgOrbLTlXOOCTJeNUQqruAWQ==",
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+                    "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
                     "optional": true,
                     "requires": {
-                        "readable-stream": "^3.0.1"
+                        "buffer": "^5.5.0",
+                        "inherits": "^2.0.4",
+                        "readable-stream": "^3.4.0"
+                    }
+                },
+                "buffer": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+                    "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+                    "optional": true,
+                    "requires": {
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.1.13"
                     }
                 },
                 "readable-stream": {
-                    "version": "3.4.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-                    "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
                     "optional": true,
                     "requires": {
                         "inherits": "^2.0.3",
@@ -5372,9 +5384,9 @@
             }
         },
         "terser": {
-            "version": "4.6.13",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.13.tgz",
-            "integrity": "sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==",
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+            "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
             "dev": true,
             "requires": {
                 "commander": "^2.20.0",
@@ -5391,16 +5403,16 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-            "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+            "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
             "dev": true,
             "requires": {
                 "cacache": "^12.0.2",
                 "find-cache-dir": "^2.1.0",
                 "is-wsl": "^1.1.0",
                 "schema-utils": "^1.0.0",
-                "serialize-javascript": "^2.1.2",
+                "serialize-javascript": "^4.0.0",
                 "source-map": "^0.6.1",
                 "terser": "^4.1.2",
                 "webpack-sources": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Kafka",
     "description": "Interact with Kafka directly in VS Code",
     "publisher": "jeppeandersen",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "engines": {
         "vscode": "^1.37.0"
     },

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -27,7 +27,7 @@ export interface Broker {
     host: string;
     port: number;
     isController: boolean;
-    isConnected: boolean;
+    isConnected?: boolean;
 }
 
 export interface Topic {
@@ -134,7 +134,7 @@ class EnsureConnectedDecorator implements Client {
 
     public async getTopicConfigs(topicId: string): Promise<ConfigEntry[]> {
         await this.waitUntilConnected();
-        return this.client.getTopicConfigs(topicId);       
+        return this.client.getTopicConfigs(topicId);
     }
 
     public async getConsumerGroupIds(): Promise<string[]> {

--- a/src/commands/cluster.ts
+++ b/src/commands/cluster.ts
@@ -17,24 +17,24 @@ export class AddClusterCommandHandler {
     }
 
     async execute(): Promise<void> {
-        const bootstrap = await vscode.window.showInputBox({ placeHolder: "Broker(s) (localhost:9092,localhost:9093...)" });
+        const bootstrap = await vscode.window.showInputBox({ placeHolder: "Broker(s) (localhost:9092,localhost:9093...)", ignoreFocusOut: true });
 
         if (!bootstrap) {
             return;
         }
 
-        const name = await vscode.window.showInputBox({ placeHolder: "Friendly name" });
+        const name = await vscode.window.showInputBox({ placeHolder: "Friendly name", ignoreFocusOut: true });
 
         if (!name) {
-            return;
+          return;
         }
 
-        const pickedAuthOption = await vscode.window.showQuickPick(this.AuthOptions, { placeHolder: "Authentication" });
+        const pickedAuthOption = await vscode.window.showQuickPick(this.AuthOptions, { placeHolder: "Authentication", ignoreFocusOut: true });
         let saslOption: SaslOption | undefined;
 
         if (pickedAuthOption && pickedAuthOption === this.AuthOptions[1]) {
-            const username = await vscode.window.showInputBox({ placeHolder: "Username" });
-            const password = await vscode.window.showInputBox({ placeHolder: "Password", password: true });
+            const username = await vscode.window.showInputBox({ placeHolder: "Username", ignoreFocusOut: true });
+            const password = await vscode.window.showInputBox({ placeHolder: "Password", password: true, ignoreFocusOut: true });
 
             if (username && password) {
                 saslOption = {
@@ -88,7 +88,6 @@ export class SelectClusterCommandHandler {
     async execute(clusterId?: string): Promise<void> {
         if (!clusterId) {
             const pickedCluster = await pickCluster(this.clusterSettings);
-            
             if (!pickedCluster) {
                 return;
             }

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -27,7 +27,7 @@ export class CreateTopicCommandHandler {
             return;
         }
 
-        const topic = await vscode.window.showInputBox({ placeHolder: "Topic name" });
+        const topic = await vscode.window.showInputBox({ placeHolder: "Topic name", ignoreFocusOut: true });
 
         if (!topic) {
             return;
@@ -36,6 +36,7 @@ export class CreateTopicCommandHandler {
         const partitions = await vscode.window.showInputBox({
             placeHolder: "Number of partitions",
             validateInput: this.validatePositiveNumber,
+            ignoreFocusOut: true
         });
 
         if (!partitions) {
@@ -45,13 +46,13 @@ export class CreateTopicCommandHandler {
         const replicationFactor = await vscode.window.showInputBox({
             placeHolder: "Replication Factor",
             validateInput: this.validatePositiveNumber,
+            ignoreFocusOut: true
         });
 
         if (!replicationFactor) {
             return;
         }
 
-        
         try {
             const client = this.clientAccessor.get(clusterId);
             const result = await client.createTopic({


### PR DESCRIPTION
- added `ignoreFocusOut: true` to the different steps of the new Kafka Cluster wizard. It was previously *very* hard to try to copy and paste credentials in the wizard, the cluster would be created with incomplete credentials when losing focus
 - ~~Made the friendly cluster name optional~~

Additionally

 - Fixed vulnerability issues by running `npm audit fix`
 - made Broker.isConnected optional, else the code wouldn't compile:
     cluster.ts?L122 - The operand of a 'delete' operator must be optional
 - upversion the extension to 0.10.0
 
 2nd commit: Updated badges in README.md

   - fixed CI badge link
   - added vscode marketplace version and installs badges