### PR TITLE
Refresh the explorer when producing messages

### DIFF
--- a/src/commands/producers.ts
+++ b/src/commands/producers.ts
@@ -3,11 +3,13 @@ import * as vscode from "vscode";
 import { performance } from "perf_hooks";
 import { ClientAccessor } from "../client";
 import { OutputChannelProvider } from "../providers/outputChannelProvider";
+import { KafkaExplorer } from "../explorer";
 
 export class ProduceRecordCommandHandler {
     constructor(
         private clientAccessor: ClientAccessor, 
-        private channelProvider: OutputChannelProvider) {
+        private channelProvider: OutputChannelProvider,
+        private explorer: KafkaExplorer) {
     }
 
     async execute(document: vscode.TextDocument, range: vscode.Range, times: number): Promise<void> {
@@ -45,6 +47,8 @@ export class ProduceRecordCommandHandler {
             const elapsed = (finishedOperation - startOperation).toFixed(2);
 
             channel.appendLine(`Produced ${times} record(s) (${elapsed}ms)`);
+
+            this.explorer.refresh();
         } catch(error) {
             const finishedOperation = performance.now();
             const elapsed = (finishedOperation - startOperation).toFixed(2);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
     // Commands
     const createTopicCommandHandler = new CreateTopicCommandHandler(clientAccessor, explorer);
-    const produceRecordCommandHandler = new ProduceRecordCommandHandler(clientAccessor, outputChannelProvider);
+    const produceRecordCommandHandler = new ProduceRecordCommandHandler(clientAccessor, outputChannelProvider, explorer);
     const startConsumerCommandHandler = new StartConsumerCommandHandler(clientAccessor, clusterSettings, consumerCollection);
     const listConsumersCommandHandler = new ListConsumersCommandHandler(consumerCollection);
     const toggleConsumerCommandHandler = new ToggleConsumerCommandHandler(consumerCollection);


### PR DESCRIPTION
Quick n' Dirty explorer refresh on each message producing request. Fixes #28.

![Dec-06-2020 13-48-36](https://user-images.githubusercontent.com/148698/101280643-8937f780-37ca-11eb-94bf-19047ec49920.gif)

Obviously, a more subtle approach would check if the message was posted to a new topic, and only then perform the explorer refresh, but I think this one is good enough for most cases.

 