### PR TITLE
Improved notification when consumer is already started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Kafka extension will be documented in this file.
 ### Changed
 - Fixed Kafka cluster wizard, no longer disappears when losing focus.
 - Moved the underlying Kafka library to KafkaJS (https://kafka.js.org/) (brings a heap of benefits such as larger API surface, less dependencies and is generally more maintained).
+- Improved notification when consumer is already started.
 
 
 ## [0.9.0] - 2020-05-30

--- a/src/commands/consumers.ts
+++ b/src/commands/consumers.ts
@@ -41,7 +41,7 @@ export class StartConsumerCommandHandler {
         const consumeUri = vscode.Uri.parse(`kafka:${startConsumerCommand.clusterId}/${startConsumerCommand.topic.id}`);
 
         if (this.consumerCollection.has(consumeUri)) {
-            vscode.window.showErrorMessage("Consumer already exists");
+            vscode.window.showInformationMessage(`Consumer already started on '${startConsumerCommand.topic.id}'`);
             return;
         }
 


### PR DESCRIPTION
Improved notification when consumer is already started, use information message instead of an error, display topic name.

Previous was : 
<img width="546" alt="Screenshot 2020-12-08 at 11 15 55" src="https://user-images.githubusercontent.com/148698/101470909-e9ec3f00-3946-11eb-8113-9264ff13e45b.png">

Now is:
<img width="660" alt="Screenshot 2020-12-08 at 10 49 35" src="https://user-images.githubusercontent.com/148698/101470937-f40e3d80-3946-11eb-8bf5-be6e71deb402.png">
