### PR TITLE
Improvements to the consumer view handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to Kafka extension will be documented in this file.
 - Refresh Kafka Explorer when producing messages, so new topics can be discovered automatically.
 - Refresh Kafka Explorer when starting a consumer.
 - Automatically select cluster when there's only one available.
+- Starting an already started consumer no longer displays an error, opens corresponding view instead
+- Fixed restarting a stopped consumer would not display the `Consumer started` message until the next message was consumed.
+- Minimize the chances of opening duplicate consumer views.
 
 ## [0.9.0] - 2020-05-30
 ### Added

--- a/src/providers/consumerVirtualTextDocumentProvider.ts
+++ b/src/providers/consumerVirtualTextDocumentProvider.ts
@@ -19,11 +19,9 @@ export class ConsumerVirtualTextDocumentProvider implements vscode.TextDocumentC
         this.disposables.push(this.consumerCollection.onDidChangeCollection((arg: any) => {
             for (const startedUri of arg.created) {
                 if (!this.buffer[startedUri.toString()]) {
-                    this.buffer[startedUri.toString()] = "Consumer: started\n\n";
-                } else {
-                    this.buffer[startedUri.toString()] += "Consumer started\n\n";
+                    this.buffer[startedUri.toString()] = '';
                 }
-
+                this.onDidChangeStatus(startedUri, 'started');
                 this.attachToConsumer(startedUri);
             }
 
@@ -82,17 +80,7 @@ export class ConsumerVirtualTextDocumentProvider implements vscode.TextDocumentC
     }
 
     public onDidCloseConsumer(uri: vscode.Uri): void {
-        let uriBuffer = this.buffer[uri.toString()];
-
-        if (!uriBuffer) {
-            return;
-        }
-
-        const line = `Consumer closed\n`;
-        uriBuffer = uriBuffer + line;
-
-        this.buffer[uri.toString()] = uriBuffer;
-        this.onDidChangeEmitter.fire(uri);
+        this.onDidChangeStatus(uri, 'closed');
     }
 
     public onDidReceiveError(error: any): void {


### PR DESCRIPTION
- Better detect existing consumer view to minimize opening duplicates, partially fixes #42
- Starting an already started consumer no longer displays an error, opens the corresponding view instead,
- Fixed restarting a stopped consumer would not display the `Consumer started` message until the next message was consumed.

This PR includes and supersedes the contents of #39 