### PR TITLE
Publish vscode-kafka.vsix after a CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,23 @@ jobs:
       - run: npm install
       - name: Lint
         run: npm run lint 
-      - name: Build webpack bundle 
-        run: npm run webpack:production      
+      - name: Build .vsix package
+        if: matrix.os != 'ubuntu-latest'
+        run: npm run package
+      - name: Build .vsix package on Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          npm run package -- -o vscode-kafka-${VERSION}-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}.vsix
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1.0
         with:
           run: npm test
+      - name: Upload linux-built vsix
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v2
+        with:
+          name: vscode-kafka
+          path: vscode-kafka*.vsix
+        
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Kafka extension will be documented in this file.
 ### Added
 - Added confirmation before deleting a cluster.
 - Added support for topic deletion. Right-click on a topic and select `Delete Topic`. Be aware that, depending on the cluster configuration (`auto.create.topics.enable:true`), deleted topics *might* be recreated automatically after a few moments.
+- Added [instructions](https://github.com/jlandersen/vscode-kafka#ci-builds) to manually install CI builds.
 
 ### Changed
 - Fixed Kafka cluster wizard, no longer disappears when losing focus.

--- a/README.md
+++ b/README.md
@@ -54,3 +54,12 @@ Consuming topics can be done by right clicking a topic in the explorer or from t
 Consumers are based on virtual documents, available in the VS Code extension API. A consumer will keep running even if you close the document in the editor. You should make sure to close the consumer explicitly, either via the command palette, the status bar element or the start/stop action button as well. The VS Code API does not support detecting if a virtual document is closed immediately. Instead, the underlying virtual document is automatically closed after two minutes if the document is closed in the editor.
 
 You can configure start offset for new consumers in settings (earliest, latest).
+
+## CI Builds
+
+vscode-kafka is built using Github Actions. Here's how to download and install the latest successful build:
+- Go to the [CI Workflow page](https://github.com/jlandersen/vscode-kafka/actions?query=workflow%3ACI+is%3Asuccess+branch%3Amaster)
+- Click on the most recent run,
+- Locate the vscode-kafka artifact down the page and download it,
+- Unzip the archive,
+- Install the vscode-kafka-*.vsix extension by following these [instructions](https://code.visualstudio.com/docs/editor/extension-gallery#_install-from-a-vsix).

--- a/package.json
+++ b/package.json
@@ -253,7 +253,8 @@
         "webpack:dev": "webpack --mode development --watch",
         "pretest": "npm run test:compile",
         "test": "node ./out/test/runTest.js",
-        "test:compile": "tsc -p ./"
+        "test:compile": "tsc -p ./",
+        "package": "vsce package"
     },
     "dependencies": {
         "glob": "^7.1.6",
@@ -274,6 +275,7 @@
         "typescript": "^4.1.2",
         "vscode-test": "^1.4.1",
         "webpack": "^5.6.0",
-        "webpack-cli": "^4.2.0"
+        "webpack-cli": "^4.2.0",
+        "vsce": "^1.81.1"
     }
 }


### PR DESCRIPTION
Fixes #41 

See the latest run on https://github.com/fbricon/vscode-kafka/actions?query=is%3Acompleted to test the results