### PR TITLE
New SASL/SCRAM support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to Kafka extension will be documented in this file.
 - Added glob patterns to filter topics (`kafka.explorer.topics.filters`) and consumer groups (`kafka.explorer.consumers.filters`) out of the Kafka explorer. See [#74](https://github.com/jlandersen/vscode-kafka/pull/74).
 - Kafka Explorer item labels can now be copied to the clipboard (supports multi selection). See [#68](https://github.com/jlandersen/vscode-kafka/issues/68).
 - Selected Cluster or Topic can now be deleted via the Delete shortcut (Cmd+Backspace on Mac). See [#79](https://github.com/jlandersen/vscode-kafka/issues/79)
+- Added SASL/SCRAM-256 and SASL/SCRAM-512 authentication support. See [#3](https://github.com/jlandersen/vscode-kafka/issues/3).
+
 
 ### Changed
 - Improved the "New cluster" and "New topic" wizards: now include validation and a back button. See [#21](https://github.com/jlandersen/vscode-kafka/issues/21).


### PR DESCRIPTION
Added SASL/SCRAM-256 and SASL/SCRAM-512 authentication mechanisms:
 
<img width="717" alt="Screenshot 2021-01-05 at 18 40 26" src="https://user-images.githubusercontent.com/148698/103679737-837a3100-4f85-11eb-89e2-27f1bcac749a.png">

Tested against a https://www.cloudkarafka.com/ cluster (Free Tier) :
- connection works (using SCRAM-256)
- listing brokers, topics, consumer group works
- producing messages works
 
<img width="474" alt="Screenshot 2021-01-05 at 18 39 47" src="https://user-images.githubusercontent.com/148698/103679659-69d8e980-4f85-11eb-9b29-bbd62892b772.png">

There are some things that still don't work against the karafka clusters:
- creating a topic fails (looks like authorization limitation), even when using the user prefix for the topic name
- ~~adding/starting a consumer fails (complains about SASL mechanism not supported)~~ fixed

Fixes #3