### PR TITLE
Add topic and consumer group filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to Kafka extension will be documented in this file.
 ### Added
 - Newly created topic or cluster is automatically selected in the Kafka Explorer. See [#61](https://github.com/jlandersen/vscode-kafka/issues/61).
 - Click on empty Kafka explorer to add a new cluster. See [#76](https//github.com/jlandersen/vscode-kafka/pull/76).
+- Added glob patterns to filter topics (`kafka.explorer.topics.filters`) and consumer groups (`kafka.explorer.consumers.filters`) out of the Kafka explorer. See [#74](https://github.com/jlandersen/vscode-kafka/pull/74).
 
 ### Changed
 - Improved the "New cluster" and "New topic" wizards: now include validation and a back button. See [#21](https://github.com/jlandersen/vscode-kafka/issues/21).
 - Newly created topic or cluster is automatically selected in the Kafka Explorer. See [#61](https://github.com/jlandersen/vscode-kafka/issues/61).
+- Internal topics are now hidden by default. See [#29](https://github.com/jlandersen/vscode-kafka/issues/29) and [#74](https://github.com/jlandersen/vscode-kafka/pull/74).
 
 ## [0.10.0] - 2021-01-02
 ### Added

--- a/package.json
+++ b/package.json
@@ -63,6 +63,16 @@
                     "default": "name",
                     "description": "Choose sorting for topics in explorer"
                 },
+                "kafka.explorer.topics.filter": {
+                    "type": "array",
+                    "default": ["__consumer_offsets", "__transaction_state", "_schemas"],
+                    "markdownDescription": "Glob patterns filtering topics out of the Kafka explorer. `*` matches any string, `?` matches a single character."
+                },
+                "kafka.explorer.consumers.filter": {
+                    "type": "array",
+                    "default": [],
+                    "markdownDescription": "Glob patterns filtering consumer groups out of the Kafka explorer. `*` matches any string, `?` matches a single character."
+                },
                 "kafka.producers.fakerjs.enabled":{
                     "type": "boolean",
                     "default":true,

--- a/src/settings/workspace.ts
+++ b/src/settings/workspace.ts
@@ -15,6 +15,8 @@ export enum TopicSortOption {
 export type InitialConsumerOffset = "latest" | "earliest";
 
 const DEFAULT_PRODUCER_LOCALE = 'en';
+const DEFAULT_TOPIC_FILTER = ['__consumer_offsets', '__transaction_state', '_schemas'];
+const DEFAULT_CONSUMER_FILTER:string[] = [];
 
 export interface WorkspaceSettings extends vscode.Disposable {
     consumerOffset: InitialConsumerOffset;
@@ -35,6 +37,8 @@ class VsCodeWorkspaceSettings implements WorkspaceSettings {
     public topicSortOption: TopicSortOption = TopicSortOption.Name;
     public producerFakerJSEnabled = true;
     public producerFakerJSLocale = DEFAULT_PRODUCER_LOCALE;
+    public topicFilters = DEFAULT_TOPIC_FILTER;
+    public consumerFilters = DEFAULT_CONSUMER_FILTER;
 
     private constructor() {
         this.configurationChangeHandlerDisposable = vscode.workspace.onDidChangeConfiguration(
@@ -56,6 +60,8 @@ class VsCodeWorkspaceSettings implements WorkspaceSettings {
         this.topicSortOption = configuration.get<TopicSortOption>("explorer.topics.sort", TopicSortOption.Name);
         this.producerFakerJSEnabled = configuration.get<boolean>("producers.fakerjs.enabled", true);
         this.producerFakerJSLocale = configuration.get<string>("producers.fakerjs.locale", DEFAULT_PRODUCER_LOCALE);
+        this.topicFilters = configuration.get<string[]>("explorer.topics.filter", DEFAULT_TOPIC_FILTER);
+        this.consumerFilters = configuration.get<string[]>("explorer.consumers.filter", DEFAULT_CONSUMER_FILTER);
     }
 
     dispose(): void {


### PR DESCRIPTION
Filter topics (`kafka.explorer.topics.filters`) and consumer groups (`kafka.explorer.consumers.filters`) out of the Kafka explorer. 
Filters support glob patterns: `*` matches any string, `?` matches a single character.
Internal topics are filtered by default (fixes #29).


https://user-images.githubusercontent.com/148698/104184565-ed765880-5413-11eb-8c2a-f015d1b8213f.mp4
