### PR TITLE
Add copy command for explorer nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Kafka extension will be documented in this file.
 - Newly created topic or cluster is automatically selected in the Kafka Explorer. See [#61](https://github.com/jlandersen/vscode-kafka/issues/61).
 - Click on empty Kafka explorer to add a new cluster. See [#76](https//github.com/jlandersen/vscode-kafka/pull/76).
 - Added glob patterns to filter topics (`kafka.explorer.topics.filters`) and consumer groups (`kafka.explorer.consumers.filters`) out of the Kafka explorer. See [#74](https://github.com/jlandersen/vscode-kafka/pull/74).
+- Kafka Explorer item labels can now be copied to the clipboard (supports multi selection). See [#68](https://github.com/jlandersen/vscode-kafka/issues/68).
 
 ### Changed
 - Improved the "New cluster" and "New topic" wizards: now include validation and a back button. See [#21](https://github.com/jlandersen/vscode-kafka/issues/21).

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "onCommand:vscode-kafka.consumer.consume",
         "onCommand:vscode-kafka.consumer.list",
         "onCommand:vscode-kafka.consumer.toggle",
+        "onCommand:vscode-kafka.explorer.copy",
         "onView:kafkaExplorer",
         "onLanguage:kafka",
         "onDebug"
@@ -178,6 +179,11 @@
                 }
             },
             {
+                "command": "vscode-kafka.explorer.copylabel",
+                "title": "Copy Label",
+                "category": "Kafka"
+            },
+            {
                 "command": "vscode-kafka.explorer.deletecluster",
                 "title": "Delete Cluster",
                 "category": "Kafka",
@@ -226,7 +232,7 @@
             },
             {
                 "command": "vscode-kafka.explorer.selectcluster",
-                "title": "Select cluster",
+                "title": "Select Cluster",
                 "category": "Kafka"
             },
             {
@@ -265,41 +271,53 @@
             "view/item/context": [
                 {
                     "command": "vscode-kafka.explorer.createtopic",
-                    "when": "view == kafkaExplorer && viewItem == topics",
+                    "when": "view == kafkaExplorer && viewItem == topics && !listMultiSelection",
                     "group": "inline"
                 },
                 {
                     "command": "vscode-kafka.explorer.deletecluster",
-                    "when": "view == kafkaExplorer && viewItem == cluster",
+                    "when": "view == kafkaExplorer && viewItem == cluster && !listMultiSelection",
                     "group": "inline"
                 },
                 {
                     "command": "vscode-kafka.consumer.consume",
-                    "when": "view == kafkaExplorer && viewItem == topic"
+                    "when": "view == kafkaExplorer && viewItem == topic && !listMultiSelection",
+                    "group":"1_kafka"
                 },
                 {
                     "command": "vscode-kafka.explorer.dumptopicmetadata",
-                    "when": "view == kafkaExplorer && viewItem == topic"
+                    "when": "view == kafkaExplorer && viewItem == topic && !listMultiSelection",
+                    "group":"1_kafka"
                 },
                 {
                     "command": "vscode-kafka.explorer.deletetopic",
-                    "when": "view == kafkaExplorer && viewItem == topic"
+                    "when": "view == kafkaExplorer && viewItem == topic && !listMultiSelection",
+                    "group":"1_kafka"
                 },
                 {
                     "command": "vscode-kafka.explorer.dumpclustermetadata",
-                    "when": "view == kafkaExplorer && viewItem == broker"
+                    "when": "view == kafkaExplorer && viewItem == broker && !listMultiSelection",
+                    "group":"1_kafka"
                 },
                 {
                     "command": "vscode-kafka.explorer.dumpbrokermetadata",
-                    "when": "view == kafkaExplorer && viewItem == broker"
+                    "when": "view == kafkaExplorer && viewItem == broker && !listMultiSelection",
+                    "group":"1_kafka"
                 },
                 {
                     "command": "vscode-kafka.explorer.deletecluster",
-                    "when": "view == kafkaExplorer && viewItem == cluster"
+                    "when": "view == kafkaExplorer && viewItem == cluster && !listMultiSelection",
+                    "group":"1_kafka"
                 },
                 {
                     "command": "vscode-kafka.explorer.selectcluster",
-                    "when": "view == kafkaExplorer && viewItem == cluster"
+                    "when": "view == kafkaExplorer && viewItem == cluster && !listMultiSelection",
+                    "group":"1_kafka"
+                },
+                {
+                    "command": "vscode-kafka.explorer.copylabel",
+                    "when": "view == kafkaExplorer",
+                    "group": "2_cutcopypaste"
                 }
             ],
             "editor/title": [
@@ -326,7 +344,15 @@
                     "name": "Explorer"
                 }
             ]
-        }
+        },
+        "keybindings":[
+            {
+                "command": "vscode-kafka.explorer.copylabel",
+                "key": "Ctrl+C",
+                "mac": "Cmd+C",
+                "when": "focusedView == kafkaExplorer"
+            }
+        ]
     },
     "scripts": {
         "vscode:prepublish": "webpack --mode production",

--- a/src/explorer/kafkaExplorer.ts
+++ b/src/explorer/kafkaExplorer.ts
@@ -6,6 +6,7 @@ import { NodeBase } from "./models/nodeBase";
 import { TreeView } from "vscode";
 import { KafkaModel } from "./models/kafka";
 import { ClusterItem } from "./models/cluster";
+import { EOL } from 'os';
 
 const TREEVIEW_ID = 'kafkaExplorer';
 
@@ -34,7 +35,8 @@ export class KafkaExplorer implements vscode.Disposable, vscode.TreeDataProvider
         this.clientAccessor = clientAccessor;
         this.root = null;
         this.tree = vscode.window.createTreeView(TREEVIEW_ID, {
-            treeDataProvider: this
+            treeDataProvider: this,
+            canSelectMany:true
         });
     }
 
@@ -89,7 +91,7 @@ export class KafkaExplorer implements vscode.Disposable, vscode.TreeDataProvider
         this.selectItem(clusterItem);
     }
 
-        /**
+    /**
      * Select the given topic name which belongs to the given cluster in the tree.
      *
      * @param clusterName the owner cluster name
@@ -114,4 +116,22 @@ export class KafkaExplorer implements vscode.Disposable, vscode.TreeDataProvider
             focus: true
         });
     }
+
+    public async copyLabelsToClipboard(nodes: NodeBase[] | undefined): Promise<void> {
+        if (!nodes) {
+            //get selected tree items (command was executed via keyboard shortcut)
+            nodes = this.tree?.selection;
+        }
+        if (nodes && nodes.length > 0) {
+            let output = '';
+            for (let i = 0; i < nodes.length; i++) {
+                if (i> 0) {
+                    output+=EOL;
+                }
+                output+=nodes[i];
+            }
+            vscode.env.clipboard.writeText(output);
+        }
+    }
+
 }

--- a/src/explorer/models/common.ts
+++ b/src/explorer/models/common.ts
@@ -64,4 +64,9 @@ class ConfigEntryItem extends NodeBase {
         this.label = configEntry.configName;
         this.description = configEntry.configValue;
     }
+
+    public toString(): string {
+        return `${this.label}=${this.description||''}`;
+    }
+
 }

--- a/src/explorer/models/nodeBase.ts
+++ b/src/explorer/models/nodeBase.ts
@@ -36,4 +36,8 @@ export abstract class NodeBase {
     getParent(): NodeBase | undefined {
         return this.parent;
     }
+
+    public toString(): string {
+        return this?.label || this.contextValue;
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ import { ClusterItem } from "./explorer/models/cluster";
 import { TopicGroupItem } from "./explorer/models/topics";
 import { ConsumerStatusBarItem } from "./views/consumerStatusBarItem";
 import { SelectedClusterStatusBarItem } from "./views/selectedClusterStatusBarItem";
+import { NodeBase } from "./explorer/models/nodeBase";
 
 export function activate(context: vscode.ExtensionContext): void {
     Context.register(context);
@@ -45,7 +46,6 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(outputChannelProvider);
     const explorer = new KafkaExplorer(workspaceSettings, clusterSettings, clientAccessor);
     context.subscriptions.push(explorer);
-    context.subscriptions.push(vscode.window.registerTreeDataProvider("kafkaExplorer", explorer));
     context.subscriptions.push(new ConsumerStatusBarItem(consumerCollection));
     context.subscriptions.push(new SelectedClusterStatusBarItem(clusterSettings));
 
@@ -93,6 +93,9 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(vscode.commands.registerCommand(
         "vscode-kafka.explorer.dumpbrokermetadata",
         handleErrors((broker?: BrokerItem) => dumpBrokerMetadataCommandHandler.execute(broker))));
+    context.subscriptions.push(vscode.commands.registerCommand(
+            "vscode-kafka.explorer.copylabel",
+            handleErrors((_item?:any, selection?: NodeBase[]) => explorer.copyLabelsToClipboard(selection))));
     context.subscriptions.push(vscode.commands.registerCommand(
         "vscode-kafka.consumer.consume",
         handleErrors((topic?: TopicItem) => startConsumerCommandHandler.execute(topic))));


### PR DESCRIPTION
Fixes #68 

~~For some reason `tree.selection` is always empty, so Cmd+C never copies anything to the clipboard. No idea why~~
@dgolovin figured out it was caused by the explorer being subscribed as disposable [twice](https://github.com/jlandersen/vscode-kafka/pull/78/files#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L48).

- copy command bound to Ctrl+C/Cmd+C
- Multi-select copy is enabled
- config items are copied as `key=value`


https://user-images.githubusercontent.com/148698/104290880-2ae1f100-54bb-11eb-86a5-e7d2b5932157.mp4
