### PR TITLE
Randomize message key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Kafka extension will be documented in this file.
 - Elements are now sorted alphabetically in the Kafka explorer. See [#63](https://github.com/jlandersen/vscode-kafka/issues/63).
 - Clusters are now sorted in the cluster selection wizard. See [#83](https://github.com/jlandersen/vscode-kafka/issues/83).
 - Currently selected cluster is now visible in the explorer and the `Select Cluster` menu is displayed only for unselected clusters. See [#82](https://github.com/jlandersen/vscode-kafka/issues/82).
+- Message keys can now be randomized in *.kafka producer files. See [#66](https://github.com/jlandersen/vscode-kafka/issues/66).
 
 ## [0.10.0] - 2021-01-02
 ### Added


### PR DESCRIPTION
The same seed is used for randomizing the key and the value, so the same randomized content can be injected in both

Fixes #66


<img width="1042" alt="Screenshot 2021-01-25 at 11 35 19" src="https://user-images.githubusercontent.com/148698/105694623-722ba100-5f01-11eb-8686-6b4707f1f2bc.png">