### PR TITLE
Add github action for releasing to marketplaces

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+    push:
+        tags:
+          - "v*"
+
+jobs:
+ build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - run: npm install
+      - name: Publish to VSCode Marketplace
+        run: npx vsce publish -p $VSCE_TOKEN
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
+      - name: Publish to Open VSX
+        run: npx ovsx publish -p $OVSX_TOKEN
+        env:
+          OVSX_TOKEN: ${{ secrets.OPENVSX_MARKETPLACE_TOKEN }}
+
+


### PR DESCRIPTION
- VS Code Marketplace requires defining a VSCODE_MARKETPLACE_TOKEN secret in GitHub
- Open VSX requires setting up an account and defining a OPENVSX_MARKETPLACE_TOKEN secret in GitHub

Fixes #93