### PR TITLE
Only show replication factor input when relevant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to Kafka extension will be documented in this file.
 ### Added
 - Extension API to contribute clusters. See [#123](https://github.com/jlandersen/vscode-kafka/issues/123).
 
+### Changed
+- Improved the "New topic" wizard: the replication factor is now read from the broker configuration. Input will be skipped if value can't be higher than 1. See [#64](https://github.com/jlandersen/vscode-kafka/issues/64).
+
 ## [0.11.0] - 2021-03-08
 ### Added
 - Newly created topic or cluster is automatically selected in the Kafka Explorer. See [#61](https://github.com/jlandersen/vscode-kafka/issues/61).

--- a/src/client/config.ts
+++ b/src/client/config.ts
@@ -1,0 +1,21 @@
+/**
+ * @see https://kafka.apache.org/documentation/#brokerconfigs
+ */
+export namespace BrokerConfigs {
+
+    /**
+    * @see https://kafka.apache.org/documentation/#brokerconfigs_default.replication.factor
+    */
+    export const DEFAULT_REPLICATION_FACTOR = 'default.replication.factor';
+
+    /**
+     * @see https://kafka.apache.org/documentation/#brokerconfigs_offsets.topic.replication.factor
+     */
+    export const OFFSETS_TOPIC_REPLICATION_FACTOR = 'offsets.topic.replication.factor';
+
+    /**
+     * @see https://kafka.apache.org/documentation/#brokerconfigs_auto.create.topics.enable
+     */
+    export const AUTO_CREATE_TOPIC_ENABLE = 'auto.create.topics.enable';
+
+}

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -1,14 +1,12 @@
-import { ClusterSettings } from "../settings";
-import { dump } from "js-yaml";
 import * as vscode from "vscode";
-
+import { dump } from "js-yaml";
+import { ClusterSettings } from "../settings";
 import { Topic, ClientAccessor } from "../client";
 import { KafkaExplorer, TopicItem } from "../explorer";
 import { OutputChannelProvider } from "../providers";
 import { addTopicWizard } from "../wizards/topics";
 import { pickClient, pickTopic } from "./common";
-
-const AUTO_CREATE_TOPIC_KEY = 'auto.create.topics.enable';
+import { BrokerConfigs } from "../client/config";
 
 export class CreateTopicCommandHandler {
 
@@ -76,7 +74,7 @@ export class DeleteTopicCommandHandler {
             if (brokers) {
                 for (let i = 0; i < brokers.length && !autoCreateTopicsEnabled; i++) {
                     const configs = await client?.getBrokerConfigs(brokers[i].id);
-                    const config = configs?.find(ce => ce.configName === AUTO_CREATE_TOPIC_KEY);
+                    const config = configs?.find(ce => ce.configName === BrokerConfigs.AUTO_CREATE_TOPIC_ENABLE);
                     if (config) {
                         autoCreateTopicsEnabled = config.configValue === 'true';
                     }
@@ -85,7 +83,7 @@ export class DeleteTopicCommandHandler {
 
             let warning = `Are you sure you want to delete topic '${topicToDelete.id}'?`;
             if (autoCreateTopicsEnabled) {
-                warning += ` The cluster is configured with '${AUTO_CREATE_TOPIC_KEY}=true', so the topic might be recreated automatically.`;
+                warning += ` The cluster is configured with '${BrokerConfigs.AUTO_CREATE_TOPIC_ENABLE}=true', so the topic might be recreated automatically.`;
             }
             const deleteConfirmation = await vscode.window.showWarningMessage(warning, 'Cancel', 'Delete');
             if (deleteConfirmation !== 'Delete') {

--- a/src/wizards/validators.ts
+++ b/src/wizards/validators.ts
@@ -55,12 +55,12 @@ export async function validatePartitions(partitions: string): Promise<string | u
     return validateFieldPositiveNumber(PARTITIONS_FIELD, partitions);
 }
 
-export async function validateReplicationFactor(replicationFactor: string): Promise<string | undefined> {
+export async function validateReplicationFactor(replicationFactor: string, max: number): Promise<string | undefined> {
     const result = validateFieldRequired(REPLICATION_FACTOR_FIELD, replicationFactor);
     if (result) {
         return result;
-    }
-    return validateFieldPositiveNumber(REPLICATION_FACTOR_FIELD, replicationFactor);
+    } 
+    return validateFieldPositiveNumber(REPLICATION_FACTOR_FIELD, replicationFactor, max);
 }
 
 // ------------------ Commons Validators
@@ -80,9 +80,12 @@ function validateFieldUniqueValue(name: string, value: string, values: string[])
     }
 }
 
-function validateFieldPositiveNumber(name: string, value: string): string | undefined {
-    const valueAsNumber = parseInt(value, 10);
+function validateFieldPositiveNumber(name: string, value: string, max?: number): string | undefined {
+    const valueAsNumber = Number(value);
     if (isNaN(valueAsNumber) || valueAsNumber < 1) {
         return `${name} must be a positive number.`;
+    }
+    if (max && valueAsNumber > max) {
+        return `${name} can not be greater than ${max}.`;
     }
 }


### PR DESCRIPTION
When creating a new topic from the wizard


- read offsets.topic.replication.factor from broker config to determine default replication factor
- fallback to default.replication.factor
- fallback to the lowest value between 3 and the number of brokers (looking at you cloudkarafka)

The max number of replicas is determined by the number of brokers.

If value <= 1, the replication factor input is not shown in the topic wizard
If value > max replicas, a validation error is displayed

Fixes #64