### PR TITLE
Bad highlighting when declaring json messages with fakerjs placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to `Tools for Apache Kafka®` are documented in this file.
 - Improved the "New topic" wizard: the replication factor is now read from the broker configuration. Input will be skipped if value can't be higher than 1. See [#64](https://github.com/jlandersen/vscode-kafka/issues/64).
 - The "Kafka Producer Log" output view is no longer shown automatically when producing messages. See [#134](https://github.com/jlandersen/vscode-kafka/issues/134).
 - A progress notification is displayed when producing messages. See [#117](https://github.com/jlandersen/vscode-kafka/issues/117).
+-Fix bad highlighting when declaring json messages with fakerjs placeholders. See [#132](https://github.com/jlandersen/vscode-kafka/issues/132).
 
 ## [0.11.0] - 2021-03-08
 ### Added

--- a/syntaxes/kafka.tmLanguage.json
+++ b/syntaxes/kafka.tmLanguage.json
@@ -6,8 +6,8 @@
     ],
     "scopeName": "source.kafka",
     "injections": {
-        "L:support.type.property-name.json, L:string.quoted.double.json": {
-            "comment": "Mustache patterns to inject the support.type.property-name.json and string.quoted.double.json scopes",
+        "L:support.type.property-name.json, L:string.quoted.double.json, L:meta.structure.dictionary.value.json": {
+            "comment": "Mustache patterns to inject the support.type.property-name.json, string.quoted.double.json and meta.structure.dictionary.value.json scopes",
             "patterns": [
                 {
                     "include": "source.kafka#kafka.value.mustache.variables"
@@ -141,15 +141,15 @@
             "comment": "Syntax coloration for Mustache tag variables used by fakerjs (ex : {{random.uuid}} )",
             "patterns": [
                 {
-                    "begin": "\\s*(?:(\\{\\{))",
-                    "end": "\\s*(?=(\\}\\}))",
+                    "begin": "\\s*\\{\\{",
+                    "end": "\\s*\\}\\}",
                     "beginCaptures": {
-                        "1": {
+                        "0": {
                             "name": "punctuation.definition.tag.variables.begin.mustache"
                         }
                     },
                     "endCaptures": {
-                        "1": {
+                        "0": {
                             "name": "punctuation.definition.tag.variables.end.mustache"
                         }
                     },


### PR DESCRIPTION
Bad highlighting when declaring json messages with fakerjs placeholders

Fixes #132

Signed-off-by: azerr <azerr@redhat.com>