### PR TITLE
Customize cluster context with provider id

### DIFF
--- a/package.json
+++ b/package.json
@@ -354,7 +354,7 @@
                 },
                 {
                     "command": "vscode-kafka.explorer.selectcluster",
-                    "when": "view == kafkaExplorer && viewItem == cluster && !listMultiSelection",
+                    "when": "view == kafkaExplorer && viewItem =~ /^cluster.*$/ && !listMultiSelection",
                     "group": "1_kafka"
                 },
                 {
@@ -364,12 +364,12 @@
                 },
                 {
                     "command": "vscode-kafka.explorer.deleteselected",
-                    "when": "view == kafkaExplorer && viewItem =~ /^cluster$|^selectedCluster$|^topic$|^consumergroupitem$/ && !listMultiSelection",
+                    "when": "view == kafkaExplorer && viewItem =~ /^cluster.*$|^selectedCluster.*$|^topic$|^consumergroupitem$/ && !listMultiSelection",
                     "group": "inline"
                 },
                 {
                     "command": "vscode-kafka.explorer.deleteselected",
-                    "when": "view == kafkaExplorer && viewItem =~ /^cluster$|^selectedCluster$|^topic$|^consumergroupitem$/ && !listMultiSelection",
+                    "when": "view == kafkaExplorer && viewItem =~ /^cluster.*$|^selectedCluster.*$|^topic$|^consumergroupitem$/ && !listMultiSelection",
                     "group": "3_modification"
                 }
             ],

--- a/src/explorer/models/cluster.ts
+++ b/src/explorer/models/cluster.ts
@@ -43,12 +43,17 @@ export class ClusterItem extends NodeBase implements Disposable {
         // because we change the label according if cluster is selected or not.
         treeItem.id = this.cluster.name;
         // update label and contextValue (used by contextual menu) according the selection state
+        let clusterContext: string;
         if (this.selected) {
-            treeItem.contextValue = 'selectedCluster';
+            clusterContext = 'selectedCluster';
             treeItem.label = GlyphChars.Check + ' ' + treeItem.label;
         } else {
-            treeItem.contextValue = 'cluster';
+            clusterContext = 'cluster';
         }
+        if (this.cluster.clusterProviderId) {
+            clusterContext = clusterContext +'-'+this.cluster.clusterProviderId;
+        }
+        treeItem.contextValue = clusterContext;
         return treeItem;
     }
 


### PR DESCRIPTION
The cluster treeview item context is now suffixed with the provider id, if present.
This allows 3rd party extensions to provide context dependent menus to the clusters they provide.

For instance, they can contribute menus like:

```json
"menus": {
	"view/item/context": [
		{
			"command": "myextension.openDashboard",
			"when": "view == kafkaExplorer && viewItem =~ /^cluster-myProviderId$|^selectedCluster-myProviderId$/ && !listMultiSelection",
			"group": "0_mygroup"
		}
	]
}

```