### PR TITLE
Fix comment snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ All notable changes to `Tools for Apache Kafka®` are documented in this file.
 - Improved the "New topic" wizard: the replication factor is now read from the broker configuration. Input will be skipped if value can't be higher than 1. See [#64](https://github.com/jlandersen/vscode-kafka/issues/64).
 - The "Kafka Producer Log" output view is no longer shown automatically when producing messages. See [#134](https://github.com/jlandersen/vscode-kafka/issues/134).
 - A progress notification is displayed when producing messages. See [#117](https://github.com/jlandersen/vscode-kafka/issues/117).
--Fix bad highlighting when declaring json messages with fakerjs placeholders. See [#132](https://github.com/jlandersen/vscode-kafka/issues/132).
+- Fix bad highlighting when declaring json messages with fakerjs placeholders. See [#132](https://github.com/jlandersen/vscode-kafka/issues/132).
 - Fix .kafka comments which breaks syntax coloration in producers and consumers. See [#161](https://github.com/jlandersen/vscode-kafka/issues/161).
+- Fix .kafka comments snippet to insert `--` instead of `---`. See [#163](https://github.com/jlandersen/vscode-kafka/pull/163).
  
 ## [0.11.0] - 2021-03-08
 ### Added

--- a/snippets/producers.json
+++ b/snippets/producers.json
@@ -69,7 +69,7 @@
             "comment"
         ],
         "body": [
-            "--- ${0}"
+            "-- ${0}"
         ],
         "description": "Adds a comment"
     },


### PR DESCRIPTION
Insert 2 dashes instead of 3, as per the comment "spec"