### PR TITLE
Hide internal strimzi topics/consumers by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to `Tools for Apache Kafka®` are documented in this file.
 ## [0.13.0]
 ### Added
 - Show cluster state in kafka file. See [#175](https://github.com/jlandersen/vscode-kafka/pull/175).
+- Hide internal [strimzi](https://strimzi.io/) topics/consumers by default. See [#176](https://github.com/jlandersen/vscode-kafka/pull/176).
 
 ## [0.12.0] - 2021-04-26
 ### Added

--- a/package.json
+++ b/package.json
@@ -85,13 +85,16 @@
                     "default": [
                         "__consumer_offsets",
                         "__transaction_state",
-                        "_schemas"
+                        "_schemas",
+                        "__strimzi*"
                     ],
                     "markdownDescription": "Glob patterns filtering topics out of the Kafka explorer. `*` matches any string, `?` matches a single character. See [here](command:vscode-kafka.open.docs.page?%5B%7B%22page%22%3A%22Explorer%22%2C%22section%22%3A%22kafkaexplorertopicsfilter%22%7D%5D) for more information."
                 },
                 "kafka.explorer.consumers.filter": {
                     "type": "array",
-                    "default": [],
+                    "default": [
+                        "strimzi-canary*"
+                    ],
                     "markdownDescription": "Glob patterns filtering consumer groups out of the Kafka explorer. `*` matches any string, `?` matches a single character. See [here](command:vscode-kafka.open.docs.page?%5B%7B%22page%22%3A%22Explorer%22%2C%22section%22%3A%22kafkaexplorerconsumersfilter%22%7D%5D) for more information."
                 },
                 "kafka.producers.fakerjs.enabled": {


### PR DESCRIPTION
This hides internal topics/consumer groups for Kafka clusters running on Kubernetes with strimzi.io