### PR TITLE
Simplify Snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `Tools for Apache Kafka®` are documented in this file.
 - Show cluster state in kafka file. See [#175](https://github.com/jlandersen/vscode-kafka/pull/175).
 - Hide internal [strimzi](https://strimzi.io/) topics/consumers by default. See [#176](https://github.com/jlandersen/vscode-kafka/pull/176).
 - Validation for available topics in `.kafka` files. See [#153](https://github.com/jlandersen/vscode-kafka/issues/153).
+- Simplify snippets. See [#180](https://github.com/jlandersen/vscode-kafka/pull/180).
 
 ## [0.12.0] - 2021-04-26
 ### Added

--- a/snippets/consumers.json
+++ b/snippets/consumers.json
@@ -9,39 +9,5 @@
             "from: ${3|earliest,latest,0|}"
         ],
         "description": "A simple consumer"
-    },
-    "partition-consumer": {
-        "prefix": [
-            "partitions-consumer"
-        ],
-        "body": [
-            "CONSUMER ${1:consumer-group-id}",
-            "topic: ${2:topic_name}",
-            "from: ${3|earliest,latest,0|}",
-            "partitions: ${4|0|}"
-        ],
-        "description": "A consumer with a partitions filter"
-    },
-    "key-format-consumer": {
-        "prefix": [
-            "key-format-consumer"
-        ],
-        "body": [
-            "CONSUMER ${1:consumer-group-id}",
-            "topic: ${2:topic_name}",
-            "key-format: ${3|none,string,double,float,integer,long,short|}"
-        ],
-        "description": "A consumer with a key format"
-    },
-    "value-format-consumer": {
-        "prefix": [
-            "value-format-consumer"
-        ],
-        "body": [
-            "CONSUMER ${1:consumer-group-id}",
-            "topic: ${2:topic_name}",
-            "value-format: ${3|none,string,double,float,integer,long,short|}"
-        ],
-        "description": "A consumer with a value format"
     }
 }

--- a/snippets/producers.json
+++ b/snippets/producers.json
@@ -1,4 +1,3 @@
-
 {
     "producer": {
         "prefix": [
@@ -31,38 +30,6 @@
             ""
         ],
         "description": "A producer generating keyed JSON records"
-    },
-    "key-format-producer": {
-        "prefix": [
-            "producer"
-        ],
-        "body": [
-            "PRODUCER ${1:key-formatted-message}",
-            "topic: ${2:topic_name}",
-            "key: ${3:mykeyq}",
-            "key-format: ${3|string,double,float,integer,long,short|}",
-            "${4:{{random.words}}}",
-            "",
-            "###",
-            ""
-        ],
-        "description": "A producer generating formatted keyed records"
-    },
-    "value-format-producer": {
-        "prefix": [
-            "producer"
-        ],
-        "body": [
-            "PRODUCER ${1:formatted-message}",
-            "topic: ${2:topic_name}",
-            "key: ${3:mykeyq}",
-            "value-format: ${3|string,double,float,integer,long,short|}",
-            "${4:{{random.words}}}",
-            "",
-            "###",
-            ""
-        ],
-        "description": "A producer generating formatted value records"
     },
     "comment": {
         "prefix": [


### PR DESCRIPTION
Simplify Snippets

Since vscode-kafka provides completions for properties (partitions, key-format, etc), related snippet which generate those fieds are not relevant and it polluate the completion result. This PR removes those snippets (partitions, key-format, etc).

Signed-off-by: azerr <azerr@redhat.com>