### PR TITLE
Use waring icon instead of error for invalid cluster

### DIFF
--- a/src/kafka-file/languageservice/services/codeLensProvider.ts
+++ b/src/kafka-file/languageservice/services/codeLensProvider.ts
@@ -50,7 +50,7 @@ export class KafkaFileCodeLenses {
             case ClientState.connected:
                 return `$(eye) `;
             case ClientState.invalid:
-                return `$(error) `;
+                return `$(warning) `;
             default:
                 return '';
         }


### PR DESCRIPTION
Use warning icon instead of error for invalid cluster

Signed-off-by: azerr <azerr@redhat.com>