### PR TITLE
docs: Fix CI badge error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tools for Apache Kafka®
 
-[![CI](https://img.shields.io/github/workflow/status/jlandersen/vscode-kafka/CI/master)](https://github.com/jlandersen/vscode-kafka/actions?query=workflow%3ACI+branch%3Amaster)
+[![CI](https://img.shields.io/github/actions/workflow/status/jlandersen/vscode-kafka/ci.yml?branch=master)](https://github.com/jlandersen/vscode-kafka/actions?query=workflow%3ACI+branch%3Amaster)
 [![Latest version](https://img.shields.io/visual-studio-marketplace/v/jeppeandersen.vscode-kafka?color=brightgreen)](https://marketplace.visualstudio.com/items?itemName=jeppeandersen.vscode-kafka)
 [![Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/jeppeandersen.vscode-kafka?logo=Installs)](https://marketplace.visualstudio.com/items?itemName=jeppeandersen.vscode-kafka)
 


### PR DESCRIPTION
Hello, this PR fixes the badge error. This was caused by the recent upgrade of badges/shields.

See the details at https://github.com/badges/shields/issues/8671

**Before**
<img width="580" alt="Screenshot 2023-01-12 at 17 05 05" src="https://user-images.githubusercontent.com/1425259/212011941-3da9265e-fdaa-4993-843d-fa93a7f60c1a.png">

**After**
<img width="459" alt="Screenshot 2023-01-12 at 17 05 11" src="https://user-images.githubusercontent.com/1425259/212011929-a8befd3a-5837-44e6-8843-34627fc8f053.png">