### PR TITLE
Add example of headers to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Define simple producers in a [.kafka](https://github.com/jlandersen/vscode-kafka
 PRODUCER keyed-message
 topic: my-topic
 key: mykeyq
+headers: header1=value1, header2=value2
 record content
 
 ###


### PR DESCRIPTION
The example of headers was on the PNG but not in the README text, so I added it to the text to make it easier to find in case someone searches specifically for the word 'headers'.