### PR TITLE
Restore wizard's pages/** packaging in vsix

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -37,7 +37,6 @@ yarn.lock
 
 # Development/Docker
 docker-compose.yml
-pages/**
 
 # Logs and cache
 *.log


### PR DESCRIPTION
The pages/ directory was accidentally excluded from packaging in https://github.com/jlandersen/vscode-kafka/commit/4e4b22888088c03615160400ae4dfae84075715c (i.e. v0.18.0)

Fixes #250 