### PR TITLE
feat: add edit consumer group offsets command

### DIFF
--- a/package.json
+++ b/package.json
@@ -600,6 +600,12 @@
 				"category": "Kafka"
 			},
 			{
+				"command": "vscode-kafka.consumer.editoffsets",
+				"title": "Edit Consumer Group Offsets",
+				"category": "Kafka",
+				"icon": "$(history)"
+			},
+			{
 				"command": "vscode-kafka.discover.clusterproviders",
 				"title": "Discover Cluster Providers",
 				"category": "Kafka",
@@ -726,9 +732,19 @@
 					"group": "1_kafka"
 				},
 				{
+					"command": "vscode-kafka.consumer.editoffsets",
+					"when": "view == kafkaExplorer && viewItem == consumergroupitem && !listMultiSelection",
+					"group": "1_kafka"
+				},
+				{
 					"command": "vscode-kafka.explorer.copylabel",
 					"when": "view == kafkaExplorer",
 					"group": "2_cutcopypaste"
+				},
+				{
+					"command": "vscode-kafka.consumer.editoffsets",
+					"when": "view == kafkaExplorer && viewItem == consumergroupitem && !listMultiSelection",
+					"group": "inline"
 				},
 				{
 					"command": "vscode-kafka.explorer.deleteselected",

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -811,7 +811,15 @@ export class PlatformaticClient implements Client {
             partitionOffsets,
         }));
 
-        await admin.alterConsumerGroupOffsets({ groupId, topics });
+        try {
+            await admin.alterConsumerGroupOffsets({ groupId, topics });
+        } catch (err: any) {
+            // The library throws MultipleErrors wrapping per-partition error codes
+            // (OFFSET_OUT_OF_RANGE, GROUP_SUBSCRIBED_TO_TOPIC, etc.).
+            // Unwrap for a clearer message.
+            const detail = err?.errors?.map((e: Error) => e.message).join('; ') ?? err?.message ?? String(err);
+            throw new Error(`Failed to alter offsets for group '${groupId}': ${detail}`);
+        }
     }
 
     async createTopic(createTopicRequest: CreateTopicRequest): Promise<any[]> {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -798,6 +798,11 @@ export class PlatformaticClient implements Client {
                 arr = [];
                 topicMap.set(spec.topic, arr);
             }
+            if (!/^\d+$/.test(spec.offset)) {
+                throw new Error(
+                    `Invalid offset '${spec.offset}' for ${spec.topic}[${spec.partition}]. Offset must be a non-negative integer.`
+                );
+            }
             arr.push({ partition: spec.partition, offset: BigInt(spec.offset) });
         }
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -772,14 +772,18 @@ export class PlatformaticClient implements Client {
     private async ensureGroupInactive(admin: Admin, groupId: string): Promise<void> {
         const groupDetails = await admin.describeGroups({ groups: [groupId] });
         const group = groupDetails.get(groupId);
-        if (group) {
-            const state = group.state?.toUpperCase();
-            if (state !== 'EMPTY' && state !== 'DEAD') {
-                throw new Error(
-                    `Consumer group '${groupId}' is in state '${group.state}'. ` +
-                    `Offsets can only be modified when the group is Empty or Dead. Stop all consumers first.`
-                );
-            }
+        if (!group) {
+            throw new Error(
+                `Unable to determine state of consumer group '${groupId}' — refusing to alter offsets.`
+            );
+        }
+
+        const state = group.state?.toUpperCase();
+        if (state !== 'EMPTY' && state !== 'DEAD') {
+            throw new Error(
+                `Consumer group '${groupId}' is in state '${group.state}'. ` +
+                `Offsets can only be modified when the group is Empty or Dead. Stop all consumers first.`
+            );
         }
     }
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -309,6 +309,12 @@ export interface ConsumerGroupOffset {
     lag: string;
 }
 
+export interface PartitionOffsetSpec {
+    topic: string;
+    partition: number;
+    offset: string;
+}
+
 export interface Client extends Disposable {
     state: ClientState;
     cluster: Cluster;
@@ -322,6 +328,7 @@ export interface Client extends Disposable {
     getConsumerGroupIds(): Promise<string[]>;
     getConsumerGroupDetails(groupId: string): Promise<ConsumerGroup>;
     deleteConsumerGroups(groupIds: string[]): Promise<void>;
+    setConsumerGroupOffsets(groupId: string, offsets: PartitionOffsetSpec[]): Promise<void>;
     createTopic(createTopicRequest: CreateTopicRequest): Promise<any[]>;
     deleteTopic(deleteTopicRequest: DeleteTopicRequest): Promise<void>;
     deleteTopicRecords(topic: string, partitions: PartitionOffset[]): Promise<void>;
@@ -387,6 +394,11 @@ class EnsureConnectedDecorator implements Client {
     public async deleteConsumerGroups(groupIds: string[]): Promise<void> {
         await this.waitUntilConnected();
         return await this.client.deleteConsumerGroups(groupIds);
+    }
+
+    public async setConsumerGroupOffsets(groupId: string, offsets: PartitionOffsetSpec[]): Promise<void> {
+        await this.waitUntilConnected();
+        return await this.client.setConsumerGroupOffsets(groupId, offsets);
     }
 
     public async createTopic(createTopicRequest: CreateTopicRequest): Promise<any[]> {
@@ -755,6 +767,42 @@ export class PlatformaticClient implements Client {
     async deleteConsumerGroups(groupIds: string[]): Promise<void> {
         const admin = await this.getKafkaAdminClient();
         await admin.deleteGroups({ groups: groupIds });
+    }
+
+    private async ensureGroupInactive(admin: Admin, groupId: string): Promise<void> {
+        const groupDetails = await admin.describeGroups({ groups: [groupId] });
+        const group = groupDetails.get(groupId);
+        if (group) {
+            const state = group.state?.toUpperCase();
+            if (state !== 'EMPTY' && state !== 'DEAD') {
+                throw new Error(
+                    `Consumer group '${groupId}' is in state '${group.state}'. ` +
+                    `Offsets can only be modified when the group is Empty or Dead. Stop all consumers first.`
+                );
+            }
+        }
+    }
+
+    async setConsumerGroupOffsets(groupId: string, offsets: PartitionOffsetSpec[]): Promise<void> {
+        const admin = await this.getKafkaAdminClient();
+        await this.ensureGroupInactive(admin, groupId);
+
+        const topicMap = new Map<string, { partition: number; offset: bigint }[]>();
+        for (const spec of offsets) {
+            let arr = topicMap.get(spec.topic);
+            if (!arr) {
+                arr = [];
+                topicMap.set(spec.topic, arr);
+            }
+            arr.push({ partition: spec.partition, offset: BigInt(spec.offset) });
+        }
+
+        const topics = Array.from(topicMap.entries()).map(([name, partitionOffsets]) => ({
+            name,
+            partitionOffsets,
+        }));
+
+        await admin.alterConsumerGroupOffsets({ groupId, topics });
     }
 
     async createTopic(createTopicRequest: CreateTopicRequest): Promise<any[]> {

--- a/src/commands/consumers.ts
+++ b/src/commands/consumers.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 
 import { pickClient, pickConsumerGroupId, pickTopic } from "./common";
 import { ConsumerCollection, ClientAccessor, createConsumerUri, ConsumerInfoUri, ConsumerLaunchState } from "../client";
+import { ConsumerGroupOffset } from "../client/client";
 import { KafkaExplorer } from "../explorer";
 import { ConsumerTableViewProvider } from "../providers";
 import { ProgressLocation, window } from "vscode";
@@ -206,13 +207,13 @@ export class DeleteConsumerGroupCommandHandler {
         try {
             // Check if there are any active consumers using this consumer group
             const activeConsumers = this.consumerCollection.getAllByConsumerGroupId(client.cluster.id, consumerGroupToDelete);
-            
+
             let warning = `Are you sure you want to delete consumer group '${consumerGroupToDelete}'?`;
             if (activeConsumers.length > 0) {
                 const consumerWord = activeConsumers.length === 1 ? 'consumer' : 'consumers';
                 warning += ` ${activeConsumers.length} active ${consumerWord} will be stopped first.`;
             }
-            
+
             const deleteConfirmation = await vscode.window.showWarningMessage(warning, 'Cancel', 'Delete');
             if (deleteConfirmation !== 'Delete') {
                 return;
@@ -231,6 +232,299 @@ export class DeleteConsumerGroupCommandHandler {
         } catch (error) {
             vscode.window.showErrorMessage(`Error deleting consumer group: ${getErrorMessage(error)}`);
         }
+    }
+}
+
+export interface EditConsumerGroupOffsetsCommand {
+    clusterId: string;
+    consumerGroupId: string;
+}
+
+export class EditConsumerGroupOffsetsCommandHandler implements vscode.Disposable {
+
+    public static commandId = 'vscode-kafka.consumer.editoffsets';
+
+    private panel: vscode.WebviewPanel | undefined;
+
+    constructor(
+        private clientAccessor: ClientAccessor,
+        private explorer: KafkaExplorer,
+        private extensionUri: vscode.Uri
+    ) {
+    }
+
+    async execute(command?: EditConsumerGroupOffsetsCommand): Promise<void> {
+        const client = await pickClient(this.clientAccessor, command?.clusterId);
+        if (!client) {
+            return;
+        }
+
+        const groupId: string | undefined = command?.consumerGroupId || await pickConsumerGroupId(client);
+        if (!groupId) {
+            return;
+        }
+
+        let groupDetails;
+        try {
+            groupDetails = await client.getConsumerGroupDetails(groupId);
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to load consumer group details: ${getErrorMessage(error)}`);
+            return;
+        }
+
+        if (groupDetails.offsets.length === 0) {
+            vscode.window.showWarningMessage(`Consumer group '${groupId}' has no committed offsets to edit.`);
+            return;
+        }
+
+        const offsets = groupDetails.offsets.sort((a, b) => {
+            const tc = a.topic.localeCompare(b.topic);
+            if (tc !== 0) { return tc; }
+            return a.partition - b.partition;
+        });
+
+        if (this.panel) {
+            this.panel.dispose();
+        }
+
+        this.panel = vscode.window.createWebviewPanel(
+            'kafkaEditOffsets',
+            `Edit Offsets: ${groupId}`,
+            vscode.ViewColumn.Active,
+            { enableScripts: true, retainContextWhenHidden: false, localResourceRoots: [this.extensionUri] }
+        );
+
+        this.panel.webview.html = this.getWebviewContent(groupId, groupDetails.state, offsets);
+
+        const messageListener = this.panel.webview.onDidReceiveMessage(async (message: any) => {
+            if (message.command !== 'submitOffsets') {
+                return;
+            }
+
+            const changed: { topic: string; partition: number; offset: string }[] = message.offsets;
+            if (!changed || changed.length === 0) {
+                vscode.window.showWarningMessage('No offsets were changed.');
+                return;
+            }
+
+            try {
+                await window.withProgress({
+                    location: ProgressLocation.Window,
+                    title: `Setting offsets for '${groupId}'...`,
+                    cancellable: false,
+                }, async () => {
+                    await client.setConsumerGroupOffsets(groupId, changed);
+                });
+
+                this.explorer.refresh();
+                this.panel?.dispose();
+                vscode.window.showInformationMessage(
+                    `Updated ${changed.length} partition offset(s) for '${groupId}' successfully`
+                );
+            } catch (error) {
+                this.panel?.webview.postMessage({ command: 'error', message: getErrorMessage(error) });
+                vscode.window.showErrorMessage(`Error setting consumer group offsets: ${getErrorMessage(error)}`);
+            }
+        });
+
+        this.panel.onDidDispose(() => {
+            messageListener.dispose();
+            this.panel = undefined;
+        });
+    }
+
+    private getWebviewContent(groupId: string, state: string, offsets: ConsumerGroupOffset[]): string {
+        const rowsHtml = offsets.map((o, i) => `
+            <tr>
+                <td>${this.escapeHtml(o.topic)}</td>
+                <td>${o.partition}</td>
+                <td class="num">${o.start}</td>
+                <td class="num">${o.end}</td>
+                <td class="num">${o.offset}</td>
+                <td class="num">${o.lag}</td>
+                <td>
+                    <input type="text" class="offset-input" id="offset-${i}"
+                           data-topic="${this.escapeHtml(o.topic)}"
+                           data-partition="${o.partition}"
+                           data-original="${o.offset}"
+                           placeholder="${o.offset}" />
+                </td>
+            </tr>`).join('\n');
+
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Edit Offsets: ${this.escapeHtml(groupId)}</title>
+    <style>
+        body { margin: 0; padding: 16px; color: var(--vscode-foreground); background: var(--vscode-editor-background); font-family: var(--vscode-font-family); font-size: var(--vscode-font-size); }
+        h2 { margin: 0 0 4px 0; }
+        .subtitle { color: var(--vscode-descriptionForeground); margin-bottom: 16px; }
+        .toolbar { display: flex; gap: 8px; margin-bottom: 12px; flex-wrap: wrap; align-items: center; }
+        button { border: none; border-radius: 3px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); padding: 5px 12px; cursor: pointer; font-size: 12px; }
+        button:hover { background: var(--vscode-button-hoverBackground); }
+        button:disabled { opacity: 0.5; cursor: default; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid var(--vscode-panel-border); padding: 6px 10px; text-align: left; }
+        th { background: var(--vscode-editor-inactiveSelectionBackground); position: sticky; top: 0; z-index: 2; }
+        .num { text-align: right; font-variant-numeric: tabular-nums; }
+        .offset-input { background: var(--vscode-input-background); color: var(--vscode-input-foreground); border: 1px solid var(--vscode-input-border, var(--vscode-panel-border)); border-radius: 3px; padding: 3px 6px; width: 100%; box-sizing: border-box; font-family: var(--vscode-editor-font-family); font-size: 12px; }
+        .offset-input.changed { border-color: var(--vscode-focusBorder); background: var(--vscode-inputValidation-infoBackground, var(--vscode-input-background)); }
+        .offset-input.invalid { border-color: var(--vscode-errorForeground); }
+        .error-bar { color: var(--vscode-errorForeground); padding: 8px; margin-bottom: 8px; display: none; }
+    </style>
+</head>
+<body>
+    <h2>Edit Consumer Group Offsets</h2>
+    <div class="subtitle">
+        Group: <strong>${this.escapeHtml(groupId)}</strong>
+        &nbsp;&middot;&nbsp;
+        State: ${this.escapeHtml(state)}
+        <span id="changedCount" style="display:none; margin-left:8px"></span>
+    </div>
+
+    <div class="toolbar">
+        <button id="fillEarliest" title="Set all to earliest (start) offset">Fill Earliest</button>
+        <button id="fillLatest" title="Set all to latest (end) offset">Fill Latest</button>
+        <button id="clearAll" title="Clear all new offset values">Clear All</button>
+        <span style="flex:1"></span>
+        <button id="submit">Apply Offsets</button>
+    </div>
+
+    <div id="errorBar" class="error-bar"></div>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Topic</th>
+                <th>Partition</th>
+                <th>Start</th>
+                <th>End</th>
+                <th>Current Offset</th>
+                <th>Lag</th>
+                <th style="min-width:120px">New Offset</th>
+            </tr>
+        </thead>
+        <tbody>
+            ${rowsHtml}
+        </tbody>
+    </table>
+
+    <script>
+        const vscode = acquireVsCodeApi();
+        const inputs = document.querySelectorAll('.offset-input');
+        const submitBtn = document.getElementById('submit');
+        const changedCountEl = document.getElementById('changedCount');
+        const errorBarEl = document.getElementById('errorBar');
+
+        function getStartOffset(input) {
+            return input.closest('tr').children[2].textContent;
+        }
+
+        function getEndOffset(input) {
+            return input.closest('tr').children[3].textContent;
+        }
+
+        function updateChangedCount() {
+            let count = 0;
+            inputs.forEach(input => {
+                const val = input.value.trim();
+                const isChanged = val !== '' && val !== input.dataset.original;
+                input.classList.toggle('changed', isChanged);
+                const isValid = val === '' || /^\\d+$/.test(val);
+                input.classList.toggle('invalid', !isValid && val !== '');
+                if (isChanged) { count++; }
+            });
+            if (count > 0) {
+                changedCountEl.textContent = count + ' changed';
+                changedCountEl.style.display = 'inline';
+            } else {
+                changedCountEl.style.display = 'none';
+            }
+        }
+
+        inputs.forEach(input => {
+            input.addEventListener('input', updateChangedCount);
+        });
+
+        document.getElementById('fillEarliest').addEventListener('click', () => {
+            inputs.forEach(input => {
+                input.value = getStartOffset(input);
+            });
+            updateChangedCount();
+        });
+
+        document.getElementById('fillLatest').addEventListener('click', () => {
+            inputs.forEach(input => {
+                input.value = getEndOffset(input);
+            });
+            updateChangedCount();
+        });
+
+        document.getElementById('clearAll').addEventListener('click', () => {
+            inputs.forEach(input => { input.value = ''; });
+            updateChangedCount();
+        });
+
+        submitBtn.addEventListener('click', () => {
+            const offsets = [];
+            let hasInvalid = false;
+
+            inputs.forEach(input => {
+                const val = input.value.trim();
+                if (val === '' || val === input.dataset.original) {
+                    return;
+                }
+                if (!/^\\d+$/.test(val)) {
+                    hasInvalid = true;
+                    return;
+                }
+                offsets.push({
+                    topic: input.dataset.topic,
+                    partition: Number(input.dataset.partition),
+                    offset: val
+                });
+            });
+
+            if (hasInvalid) {
+                errorBarEl.textContent = 'Some offset values are invalid. Offsets must be non-negative integers.';
+                errorBarEl.style.display = 'block';
+                return;
+            }
+            errorBarEl.style.display = 'none';
+
+            if (offsets.length === 0) {
+                errorBarEl.textContent = 'No offsets were changed. Enter new values in the "New Offset" column.';
+                errorBarEl.style.display = 'block';
+                return;
+            }
+
+            submitBtn.disabled = true;
+            submitBtn.textContent = 'Applying...';
+            vscode.postMessage({ command: 'submitOffsets', offsets });
+        });
+
+        window.addEventListener('message', (event) => {
+            const msg = event.data;
+            if (msg.command === 'error') {
+                errorBarEl.textContent = msg.message;
+                errorBarEl.style.display = 'block';
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'Apply Offsets';
+            }
+        });
+    </script>
+</body>
+</html>`;
+    }
+
+    private escapeHtml(text: string): string {
+        return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+
+    dispose(): void {
+        this.panel?.dispose();
     }
 }
 

--- a/src/commands/consumers.ts
+++ b/src/commands/consumers.ts
@@ -1,8 +1,7 @@
 import * as vscode from "vscode";
 
 import { pickClient, pickConsumerGroupId, pickTopic } from "./common";
-import { ConsumerCollection, ClientAccessor, createConsumerUri, ConsumerInfoUri, ConsumerLaunchState } from "../client";
-import { ConsumerGroupOffset } from "../client/client";
+import { ConsumerCollection, ClientAccessor, createConsumerUri, ConsumerInfoUri, ConsumerLaunchState, ConsumerGroupOffset, ConsumerGroup } from "../client";
 import { KafkaExplorer } from "../explorer";
 import { ConsumerTableViewProvider } from "../providers";
 import { ProgressLocation, window } from "vscode";
@@ -264,7 +263,7 @@ export class EditConsumerGroupOffsetsCommandHandler implements vscode.Disposable
             return;
         }
 
-        let groupDetails;
+        let groupDetails: ConsumerGroup;
         try {
             groupDetails = await client.getConsumerGroupDetails(groupId);
         } catch (error) {

--- a/src/commands/consumers.ts
+++ b/src/commands/consumers.ts
@@ -239,11 +239,16 @@ export interface EditConsumerGroupOffsetsCommand {
     consumerGroupId: string;
 }
 
+type OffsetsWebviewMessage = {
+    command: 'submitOffsets';
+    offsets: { topic: string; partition: number; offset: string }[];
+};
+
 export class EditConsumerGroupOffsetsCommandHandler implements vscode.Disposable {
 
     public static commandId = 'vscode-kafka.consumer.editoffsets';
 
-    private panel: vscode.WebviewPanel | undefined;
+    private panels = new Map<string, vscode.WebviewPanel>();
 
     constructor(
         private clientAccessor: ClientAccessor,
@@ -282,25 +287,28 @@ export class EditConsumerGroupOffsetsCommandHandler implements vscode.Disposable
             return a.partition - b.partition;
         });
 
-        if (this.panel) {
-            this.panel.dispose();
+        const existing = this.panels.get(groupId);
+        if (existing) {
+            existing.reveal();
+            return;
         }
 
-        this.panel = vscode.window.createWebviewPanel(
+        const panel = vscode.window.createWebviewPanel(
             'kafkaEditOffsets',
             `Edit Offsets: ${groupId}`,
             vscode.ViewColumn.Active,
-            { enableScripts: true, retainContextWhenHidden: false, localResourceRoots: [this.extensionUri] }
+            { enableScripts: true, retainContextWhenHidden: true, localResourceRoots: [this.extensionUri] }
         );
+        this.panels.set(groupId, panel);
 
-        this.panel.webview.html = this.getWebviewContent(groupId, groupDetails.state, offsets);
+        panel.webview.html = this.getWebviewContent(groupId, groupDetails.state, offsets);
 
-        const messageListener = this.panel.webview.onDidReceiveMessage(async (message: any) => {
+        const messageListener = panel.webview.onDidReceiveMessage(async (message: OffsetsWebviewMessage) => {
             if (message.command !== 'submitOffsets') {
                 return;
             }
 
-            const changed: { topic: string; partition: number; offset: string }[] = message.offsets;
+            const changed = message.offsets;
             if (!changed || changed.length === 0) {
                 vscode.window.showWarningMessage('No offsets were changed.');
                 return;
@@ -316,37 +324,41 @@ export class EditConsumerGroupOffsetsCommandHandler implements vscode.Disposable
                 });
 
                 this.explorer.refresh();
-                this.panel?.dispose();
+                panel.dispose();
                 vscode.window.showInformationMessage(
                     `Updated ${changed.length} partition offset(s) for '${groupId}' successfully`
                 );
             } catch (error) {
-                this.panel?.webview.postMessage({ command: 'error', message: getErrorMessage(error) });
+                panel.webview.postMessage({ command: 'error', message: getErrorMessage(error) });
                 vscode.window.showErrorMessage(`Error setting consumer group offsets: ${getErrorMessage(error)}`);
             }
         });
 
-        this.panel.onDidDispose(() => {
+        panel.onDidDispose(() => {
             messageListener.dispose();
-            this.panel = undefined;
+            this.panels.delete(groupId);
         });
     }
 
     private getWebviewContent(groupId: string, state: string, offsets: ConsumerGroupOffset[]): string {
+        const fmtCell = (val: string) => val === '?'
+            ? `<span class="unavailable">N/A</span>`
+            : this.escapeHtml(val);
+
         const rowsHtml = offsets.map((o, i) => `
             <tr>
                 <td>${this.escapeHtml(o.topic)}</td>
-                <td>${o.partition}</td>
-                <td class="num">${o.start}</td>
-                <td class="num">${o.end}</td>
-                <td class="num">${o.offset}</td>
-                <td class="num">${o.lag}</td>
+                <td>${this.escapeHtml(String(o.partition))}</td>
+                <td class="num">${fmtCell(o.start)}</td>
+                <td class="num">${fmtCell(o.end)}</td>
+                <td class="num">${this.escapeHtml(o.offset)}</td>
+                <td class="num">${fmtCell(o.lag)}</td>
                 <td>
                     <input type="text" class="offset-input" id="offset-${i}"
                            data-topic="${this.escapeHtml(o.topic)}"
-                           data-partition="${o.partition}"
-                           data-original="${o.offset}"
-                           placeholder="${o.offset}" />
+                           data-partition="${this.escapeHtml(String(o.partition))}"
+                           data-original="${this.escapeHtml(o.offset)}"
+                           placeholder="${this.escapeHtml(o.offset)}" />
                 </td>
             </tr>`).join('\n');
 
@@ -371,6 +383,7 @@ export class EditConsumerGroupOffsetsCommandHandler implements vscode.Disposable
         .offset-input { background: var(--vscode-input-background); color: var(--vscode-input-foreground); border: 1px solid var(--vscode-input-border, var(--vscode-panel-border)); border-radius: 3px; padding: 3px 6px; width: 100%; box-sizing: border-box; font-family: var(--vscode-editor-font-family); font-size: 12px; }
         .offset-input.changed { border-color: var(--vscode-focusBorder); background: var(--vscode-inputValidation-infoBackground, var(--vscode-input-background)); }
         .offset-input.invalid { border-color: var(--vscode-errorForeground); }
+        .unavailable { color: var(--vscode-descriptionForeground); font-style: italic; }
         .error-bar { color: var(--vscode-errorForeground); padding: 8px; margin-bottom: 8px; display: none; }
     </style>
 </head>
@@ -418,11 +431,15 @@ export class EditConsumerGroupOffsetsCommandHandler implements vscode.Disposable
         const errorBarEl = document.getElementById('errorBar');
 
         function getStartOffset(input) {
-            return input.closest('tr').children[2].textContent;
+            return input.closest('tr').children[2].textContent.trim();
         }
 
         function getEndOffset(input) {
-            return input.closest('tr').children[3].textContent;
+            return input.closest('tr').children[3].textContent.trim();
+        }
+
+        function isAvailable(val) {
+            return val !== '' && val !== 'N/A' && /^\\d+$/.test(val);
         }
 
         function updateChangedCount() {
@@ -449,14 +466,16 @@ export class EditConsumerGroupOffsetsCommandHandler implements vscode.Disposable
 
         document.getElementById('fillEarliest').addEventListener('click', () => {
             inputs.forEach(input => {
-                input.value = getStartOffset(input);
+                const val = getStartOffset(input);
+                if (isAvailable(val)) { input.value = val; }
             });
             updateChangedCount();
         });
 
         document.getElementById('fillLatest').addEventListener('click', () => {
             inputs.forEach(input => {
-                input.value = getEndOffset(input);
+                const val = getEndOffset(input);
+                if (isAvailable(val)) { input.value = val; }
             });
             updateChangedCount();
         });
@@ -523,7 +542,10 @@ export class EditConsumerGroupOffsetsCommandHandler implements vscode.Disposable
     }
 
     dispose(): void {
-        this.panel?.dispose();
+        for (const panel of this.panels.values()) {
+            panel.dispose();
+        }
+        this.panels.clear();
     }
 }
 

--- a/src/commands/consumers.ts
+++ b/src/commands/consumers.ts
@@ -206,13 +206,13 @@ export class DeleteConsumerGroupCommandHandler {
         try {
             // Check if there are any active consumers using this consumer group
             const activeConsumers = this.consumerCollection.getAllByConsumerGroupId(client.cluster.id, consumerGroupToDelete);
-
+            
             let warning = `Are you sure you want to delete consumer group '${consumerGroupToDelete}'?`;
             if (activeConsumers.length > 0) {
                 const consumerWord = activeConsumers.length === 1 ? 'consumer' : 'consumers';
                 warning += ` ${activeConsumers.length} active ${consumerWord} will be stopped first.`;
             }
-
+            
             const deleteConfirmation = await vscode.window.showWarningMessage(warning, 'Cancel', 'Delete');
             if (deleteConfirmation !== 'Delete') {
                 return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,8 @@ import {
     DeleteClusterRequest,
     DeleteConsumerGroupCommand,
     DeleteConsumerGroupCommandHandler,
+    EditConsumerGroupOffsetsCommand,
+    EditConsumerGroupOffsetsCommandHandler,
     DeleteTopicCommandHandler,
     DeleteTopicRecordsCommandHandler,
     DumpBrokerMetadataCommandHandler,
@@ -136,6 +138,8 @@ export function activate(context: vscode.ExtensionContext): KafkaExtensionPartic
     const stopConsumerCommandHandler = new StopConsumerCommandHandler(clientAccessor, consumerCollection, explorer);
     const listConsumersCommandHandler = new ListConsumersCommandHandler(consumerCollection, consumerTableViewProvider);
     const deleteConsumerGroupCommandHandler = new DeleteConsumerGroupCommandHandler(clientAccessor, consumerCollection, explorer);
+    const editConsumerGroupOffsetsCommandHandler = new EditConsumerGroupOffsetsCommandHandler(clientAccessor, explorer, context.extensionUri);
+    context.subscriptions.push(editConsumerGroupOffsetsCommandHandler);
     const addClusterCommandHandler = new AddClusterCommandHandler(clusterSettings, schemaRegistrySettings, clientAccessor, explorer, context);
     const saveClusterCommandHandler = new SaveClusterCommandHandler(clusterSettings, explorer);
     const deleteClusterCommandHandler = new DeleteClusterCommandHandler(clusterSettings, clientAccessor, explorer, consumerCollection);
@@ -244,6 +248,9 @@ export function activate(context: vscode.ExtensionContext): KafkaExtensionPartic
     context.subscriptions.push(vscode.commands.registerCommand(
         DeleteConsumerGroupCommandHandler.commandId,
         handleErrors((command: DeleteConsumerGroupCommand) => deleteConsumerGroupCommandHandler.execute(command))));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        EditConsumerGroupOffsetsCommandHandler.commandId,
+        handleErrors((command: EditConsumerGroupOffsetsCommand) => editConsumerGroupOffsetsCommandHandler.execute(command))));
     context.subscriptions.push(vscode.commands.registerCommand(ProduceRecordCommandHandler.commandId,
         handleErrors((command: ProduceRecordCommand, times: number) => produceRecordCommandHandler.execute(command, times))));
     context.subscriptions.push(vscode.commands.registerCommand(ProduceRecordWithInputCommandHandler.commandId,


### PR DESCRIPTION
## Edit Consumer Group Offsets
  Adds a new command (`Edit Consumer Group Offsets`) that lets users alter committed offsets for a consumer group directly from the explorer tree.
  - Opens a webview panel showing all topic-partition offsets for the group, with start/end/current/lag columns
  - Supports setting offsets individually or bulk-filling to earliest/latest
  - Validates that the group is inactive (Empty/Dead) before applying changes
  - Input validation: only non-negative integers accepted, per-partition error unwrapping for clear diagnostics